### PR TITLE
ci(image_build): don't cancel in-progress builds

### DIFF
--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   ami-build:
@@ -24,6 +24,7 @@ jobs:
     if: github.event.inputs.image == 'true'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         region: [us-east-2, ap-southeast-5]
     defaults:


### PR DESCRIPTION
## Summary
- Set `concurrency.cancel-in-progress: false` so re-triggering the workflow queues behind the running build instead of cancelling it
- Set `strategy.fail-fast: false` so a failure in one region's matrix leg doesn't cancel the other leg mid-flight

## Why
Cancellation skips Packer's cleanup, leaving orphaned EC2 instances, security groups, key pairs, and partial AMIs/snapshots in the AWS account. There's no clean programmatic recovery for this — the mitigation is to avoid cancellation in the first place and tell people not to manually cancel runs.

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` with `image=true` and confirm both region legs run to completion (or fail) independently
- [ ] Push a second commit while a build is running and confirm the new run queues instead of cancelling the first