### PR TITLE
docs: add CLAUDE.md with fork and image_build gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Repo notes
+
+This is a fork. `origin` → `frgrisk/runner-images`, `upstream` → `actions/runner-images`.
+
+- When opening PRs, ALWAYS pass `--repo frgrisk/runner-images` to `gh pr create`. Without it, `gh` defaults to the upstream parent and the PR lands on `actions/runner-images`.
+- `.github/workflows/image_build.yaml` builds AMIs via Packer over a matrix of AWS regions. Do NOT re-enable `concurrency.cancel-in-progress` or `strategy.fail-fast` here — cancellation skips Packer's cleanup and leaves orphaned EC2 instances, security groups, key pairs, and partial AMIs/snapshots in the AWS account.


### PR DESCRIPTION
## Summary
Adds a top-level `CLAUDE.md` capturing two repo-specific gotchas that have already bitten us:

- **Fork PR target.** `origin` is the `frgrisk` fork but `upstream` is `actions/runner-images`. `gh pr create` defaults to the upstream parent, so PRs must be explicitly targeted with `--repo frgrisk/runner-images`.
- **Packer cleanup on cancellation.** Documents why `image_build.yaml` has `concurrency.cancel-in-progress: false` and `strategy.fail-fast: false` (see #11) — cancellation skips Packer's cleanup and leaves orphaned EC2 instances, security groups, key pairs, and partial AMIs/snapshots.

## Test plan
- [ ] Sanity-check the rendered file on the PR