### PR TITLE
Share Ubuntu AMI with account 042008443740

### DIFF
--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -17,6 +17,7 @@ source "amazon-ebs" "build_image" {
   ami_users = [
     "702719119055",
     "630261574551",
+    "042008443740",
   ]
 
   subnet_filter {


### PR DESCRIPTION
Adds AWS account `042008443740` to the `ami_users` share list in `images/ubuntu/templates/source.ubuntu.pkr.hcl` so the generated Ubuntu AMI is shared with that account.