### PR TITLE
Switch image build to Ubuntu 24.04 and add optional arm64 builds

### DIFF
--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -49,4 +49,4 @@ jobs:
         env:
           AWS_MAX_ATTEMPTS: 240
           AWS_POLL_DELAY_SECONDS: 30
-        run: packer build -var "region=${{ matrix.region }}" -only="ubuntu-22_04.amazon-ebs.build_image" -var=image_os=ubuntu22 .
+        run: packer build -var "region=${{ matrix.region }}" -only="ubuntu-24_04.amazon-ebs.build_image" -var=image_os=ubuntu24 .

--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -5,13 +5,42 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      x86_64:
+        description: "Build x86_64 image"
+        type: boolean
+        default: true
+      arm64:
+        description: "Build arm64 image"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.pick.outputs.architectures }}
+    steps:
+      - name: Select architectures
+        id: pick
+        # Push to main builds x86_64 only. workflow_dispatch honors the
+        # x86_64 / arm64 checkboxes (ticking neither builds nothing).
+        run: |
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo 'architectures=["x86_64"]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          archs=()
+          if [ "${{ github.event.inputs.x86_64 }}" = "true" ]; then archs+=(x86_64); fi
+          if [ "${{ github.event.inputs.arm64 }}" = "true" ]; then archs+=(arm64); fi
+          echo "architectures=$(jq -cn '$ARGS.positional' --args "${archs[@]}")" >> "$GITHUB_OUTPUT"
+
   ami-build:
+    needs: setup
     permissions:
       id-token: write
       contents: read
@@ -20,6 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         region: [us-east-2, ap-southeast-5]
+        architecture: ${{ fromJSON(needs.setup.outputs.architectures) }}
     defaults:
       run:
         working-directory: ./images/ubuntu/templates
@@ -49,4 +79,12 @@ jobs:
         env:
           AWS_MAX_ATTEMPTS: 240
           AWS_POLL_DELAY_SECONDS: 30
-        run: packer build -var "region=${{ matrix.region }}" -only="ubuntu-24_04.amazon-ebs.build_image" -var=image_os=ubuntu24 .
+        run: |
+          if [ "${{ matrix.architecture }}" = "arm64" ]; then
+            only="ubuntu-24_04-arm64.amazon-ebs.build_image_arm64"
+            image_os="ubuntu24-arm64"
+          else
+            only="ubuntu-24_04.amazon-ebs.build_image"
+            image_os="ubuntu24"
+          fi
+          packer build -var "region=${{ matrix.region }}" -only="$only" -var="image_os=$image_os" .

--- a/images/ubuntu/scripts/build/install-consul.sh
+++ b/images/ubuntu/scripts/build/install-consul.sh
@@ -5,9 +5,19 @@
 ################################################################################
 
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/os.sh
+
+if is_x64; then
+  consul_arch="amd64"
+elif is_arm64; then
+  consul_arch="arm64"
+else
+  echo "Unsupported architecture"
+  exit 1
+fi
 
 # Install Consul
-download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/consul/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/consul/latest | jq -r ".builds[] | select((.arch==\"$consul_arch\") and (.os==\"linux\")).url")
 archive_path=$(download_with_retry "${download_url}")
 unzip -o -qq "$archive_path" -d /usr/local/bin
 

--- a/images/ubuntu/scripts/build/install-runner-package.sh
+++ b/images/ubuntu/scripts/build/install-runner-package.sh
@@ -6,8 +6,18 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/os.sh
 
-download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-linux-x64-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
+if is_x64; then
+  runner_arch="x64"
+elif is_arm64; then
+  runner_arch="arm64"
+else
+  echo "Unsupported architecture"
+  exit 1
+fi
+
+download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-linux-'"${runner_arch}"'-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
 archive_name="${download_url##*/}"
 archive_path=$(download_with_retry "$download_url")
 

--- a/images/ubuntu/scripts/build/install-vault.sh
+++ b/images/ubuntu/scripts/build/install-vault.sh
@@ -5,9 +5,19 @@
 ################################################################################
 
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/os.sh
+
+if is_x64; then
+  vault_arch="amd64"
+elif is_arm64; then
+  vault_arch="arm64"
+else
+  echo "Unsupported architecture"
+  exit 1
+fi
 
 # Install Vault
-download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/vault/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/vault/latest | jq -r ".builds[] | select((.arch==\"$vault_arch\") and (.os==\"linux\")).url")
 archive_path=$(download_with_retry "${download_url}")
 unzip -o -qq "$archive_path" -d /usr/local/bin
 

--- a/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
@@ -1,5 +1,5 @@
 build {
-  sources = ["source.amazon-ebs.build_image"]
+  sources = ["source.amazon-ebs.build_image_arm64"]
   name = "ubuntu-24_04-arm64"
 
   provisioner "shell" {
@@ -98,7 +98,12 @@ provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
+      "${path.root}/../scripts/build/install-consul.sh",
+      "${path.root}/../scripts/build/install-vault.sh",
+      "${path.root}/../scripts/build/install-terraform.sh",
+      "${path.root}/../scripts/build/install-packer.sh",
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-apt-common.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-azure-cli.sh",
@@ -125,13 +130,13 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-nginx.sh",
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-playwright.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-selenium.sh",
-      "${path.root}/../scripts/build/install-packer.sh",
       "${path.root}/../scripts/build/install-vcpkg.sh",
       "${path.root}/../scripts/build/configure-dpkg.sh",
       "${path.root}/../scripts/build/install-yq.sh",
@@ -216,11 +221,6 @@ provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = ["${path.root}/../scripts/build/post-build-validation.sh"]
-  }
-
-  provisioner "shell" {
-    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    inline          = ["sleep 30", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]
   }
 
 }

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -98,7 +98,12 @@ provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
+      "${path.root}/../scripts/build/install-consul.sh",
+      "${path.root}/../scripts/build/install-vault.sh",
+      "${path.root}/../scripts/build/install-terraform.sh",
+      "${path.root}/../scripts/build/install-packer.sh",
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-apt-common.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-azure-cli.sh",
@@ -131,6 +136,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-nginx.sh",
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-playwright.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-postgresql.sh",
@@ -139,7 +145,6 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-julia.sh",
       "${path.root}/../scripts/build/install-selenium.sh",
-      "${path.root}/../scripts/build/install-packer.sh",
       "${path.root}/../scripts/build/install-vcpkg.sh",
       "${path.root}/../scripts/build/configure-dpkg.sh",
       "${path.root}/../scripts/build/install-yq.sh",
@@ -226,11 +231,6 @@ provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = ["${path.root}/../scripts/build/post-build-validation.sh"]
-  }
-
-  provisioner "shell" {
-    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    inline          = ["sleep 30", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]
   }
 
 }

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -1,5 +1,5 @@
 local "aws_ami_name_x86_64" {
-  expression = "GitHub Actions Runner Ubuntu 22.04 ${formatdate("YYYY-MM-DD hh.mm ZZZ", timestamp())} x86_64"
+  expression = "GitHub Actions Runner Ubuntu 24.04 ${formatdate("YYYY-MM-DD hh.mm ZZZ", timestamp())} x86_64"
 }
 
 packer {
@@ -42,7 +42,7 @@ source "amazon-ebs" "build_image" {
 
   source_ami_filter {
     filters = {
-      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+      name                = "ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-amd64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -2,6 +2,14 @@ local "aws_ami_name_x86_64" {
   expression = "GitHub Actions Runner Ubuntu 24.04 ${formatdate("YYYY-MM-DD hh.mm ZZZ", timestamp())} x86_64"
 }
 
+local "ami_users" {
+  expression = [
+    "702719119055",
+    "630261574551",
+    "042008443740",
+  ]
+}
+
 packer {
   required_plugins {
     amazon = {
@@ -14,11 +22,7 @@ packer {
 source "amazon-ebs" "build_image" {
   ami_name = local.aws_ami_name_x86_64
 
-  ami_users = [
-    "702719119055",
-    "630261574551",
-    "042008443740",
-  ]
+  ami_users = local.ami_users
 
   subnet_filter {
     filters = {
@@ -43,6 +47,55 @@ source "amazon-ebs" "build_image" {
   source_ami_filter {
     filters = {
       name                = "ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+  ssh_username = "ubuntu"
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_type           = "gp3"
+    volume_size           = 120
+    delete_on_termination = true
+  }
+}
+
+local "aws_ami_name_arm64" {
+  expression = "GitHub Actions Runner Ubuntu 24.04 ${formatdate("YYYY-MM-DD hh.mm ZZZ", timestamp())} arm64"
+}
+
+source "amazon-ebs" "build_image_arm64" {
+  ami_name = local.aws_ami_name_arm64
+
+  ami_users = local.ami_users
+
+  subnet_filter {
+    filters = {
+      "tag:Environment" : "github-actions-runners*"
+      "tag:Name" : "*-public-*"
+    }
+    random = true
+  }
+
+  associate_public_ip_address = true
+
+  ssh_interface = "public_ip"
+
+  spot_instance_types = [
+    "c7g.xlarge",
+    "c6g.xlarge",
+  ]
+
+  spot_price = "auto"
+
+  region = var.region
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-arm64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }


### PR DESCRIPTION
## Summary

- **Switch the CI image build from Ubuntu 22.04 to 24.04 (Noble):** repoint the shared Packer source to the Noble base AMI and target the `ubuntu-24_04` build, porting the fork's customizations (consul / vault / terraform / runner-package / playwright, plus removal of the Azure `waagent` deprovision step) onto the 24.04 templates.
- **Add optional arm64 (Graviton) builds, off by default.** A new `build_image_arm64` Packer source builds the Noble arm64 base AMI on Graviton spot instances. The fork install scripts that hardcoded x86 (`install-consul`, `install-vault`, `install-runner-package`) now detect architecture.
- **`workflow_dispatch` gains `x86_64` / `arm64` checkboxes.** Push to `main` builds x86_64 only; a manual run builds whichever boxes are ticked (a `setup` job turns the selection into the build matrix; ticking neither builds nothing).

## Notes

- The 22.04 build blocks are left in place (unused) to minimize upstream-merge churn.
- Not yet exercised by a real build (no AWS credentials at authoring time): the Noble base-AMI name + `owners = ["amazon"]` filter, Graviton spot availability in `ap-southeast-5`, and the arm64 root device name. These fail fast/cheap on the first arm64 dispatch.
