### PR TITLE
fix(ci): fix failing runner image builds in the workflow

### DIFF
--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -79,10 +79,6 @@ jobs:
         env:
           AWS_MAX_ATTEMPTS: 240
           AWS_POLL_DELAY_SECONDS: 30
-          # Verbose debug logging. PACKER_LOG enables trace output; the log is
-          # also written to PACKER_LOG_PATH and uploaded as an artifact below.
-          PACKER_LOG: 1
-          PACKER_LOG_PATH: packer-${{ matrix.architecture }}-${{ matrix.region }}.log
         run: |
           if [ "${{ matrix.architecture }}" = "arm64" ]; then
             only="ubuntu-24_04-arm64.amazon-ebs.build_image_arm64"
@@ -92,11 +88,3 @@ jobs:
             image_os="ubuntu24"
           fi
           packer build -var "region=${{ matrix.region }}" -only="$only" -var="image_os=$image_os" .
-
-      - name: Upload Packer debug log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: packer-log-${{ matrix.architecture }}-${{ matrix.region }}
-          path: images/ubuntu/templates/packer-${{ matrix.architecture }}-${{ matrix.region }}.log
-          if-no-files-found: warn

--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -79,6 +79,10 @@ jobs:
         env:
           AWS_MAX_ATTEMPTS: 240
           AWS_POLL_DELAY_SECONDS: 30
+          # Verbose debug logging. PACKER_LOG enables trace output; the log is
+          # also written to PACKER_LOG_PATH and uploaded as an artifact below.
+          PACKER_LOG: 1
+          PACKER_LOG_PATH: packer-${{ matrix.architecture }}-${{ matrix.region }}.log
         run: |
           if [ "${{ matrix.architecture }}" = "arm64" ]; then
             only="ubuntu-24_04-arm64.amazon-ebs.build_image_arm64"
@@ -88,3 +92,11 @@ jobs:
             image_os="ubuntu24"
           fi
           packer build -var "region=${{ matrix.region }}" -only="$only" -var="image_os=$image_os" .
+
+      - name: Upload Packer debug log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: packer-log-${{ matrix.architecture }}-${{ matrix.region }}
+          path: images/ubuntu/templates/packer-${{ matrix.architecture }}-${{ matrix.region }}.log
+          if-no-files-found: warn

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -25,7 +25,11 @@ Describe "fwupd removed" {
 
 # https://github.com/actions/runner-images/issues/13770
 # Linux kernel 6.17 changed read_ahead_kb from 128 to 4096 on Azure VMs, causing I/O thrashing
-Describe "ReadAhead udev rule" -Skip:(Test-IsUbuntu22) {
+# AWS Nitro presents EBS volumes as nvme* (no sd* devices), so this rule is a
+# harmless no-op and the device-level check below can never pass. Skip the group
+# when no sd* devices exist (extends the upstream -Skip rather than restructuring,
+# to keep future merges clean).
+Describe "ReadAhead udev rule" -Skip:(Test-IsUbuntu22 -or -not (Get-ChildItem "/sys/block/sd*" -ErrorAction SilentlyContinue)) {
     It "udev rule file exists" {
         "/etc/udev/rules.d/99-readahead.rules" | Should -Exist
     }

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -28,8 +28,11 @@ Describe "fwupd removed" {
 # AWS Nitro presents EBS volumes as nvme* (no sd* devices), so this rule is a
 # harmless no-op and the device-level check below can never pass. Skip the group
 # when no sd* devices exist (extends the upstream -Skip rather than restructuring,
-# to keep future merges clean).
-Describe "ReadAhead udev rule" -Skip:(Test-IsUbuntu22 -or -not (Get-ChildItem "/sys/block/sd*" -ErrorAction SilentlyContinue)) {
+# to keep future merges clean). NOTE: (Test-IsUbuntu22) MUST stay parenthesized so
+# the expression parses in expression mode; a bare `Test-IsUbuntu22 -or ...` is read
+# in command mode, passing -or/-not as arguments to the function and silently
+# evaluating to $false (the test would then never skip).
+Describe "ReadAhead udev rule" -Skip:((Test-IsUbuntu22) -or -not (Get-ChildItem "/sys/block/sd*" -ErrorAction SilentlyContinue)) {
     It "udev rule file exists" {
         "/etc/udev/rules.d/99-readahead.rules" | Should -Exist
     }

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -199,9 +199,9 @@ provisioner "shell" {
 
   provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    pause_before        = "5m0s"
+    pause_before        = "10m0s"
     scripts             = ["${path.root}/../scripts/build/cleanup.sh"]
-    start_retry_timeout = "10m"
+    start_retry_timeout = "15m"
   }
 
   provisioner "shell" {

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -199,7 +199,7 @@ provisioner "shell" {
 
   provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    pause_before        = "10m0s"
+    pause_before        = "5m0s"
     scripts             = ["${path.root}/../scripts/build/cleanup.sh"]
     start_retry_timeout = "15m"
   }

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -37,7 +37,7 @@ source "amazon-ebs" "build_image" {
   ssh_interface = "public_ip"
 
   spot_instance_types = [
-    "c7i.xlarge",
+    "c7i-flex.xlarge",
   ]
 
   spot_price = "auto"

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -34,7 +34,7 @@ source "amazon-ebs" "build_image" {
 
   associate_public_ip_address = true
 
-  ssh_interface = "public_ip"
+  ssh_interface = "private_ip"
 
   spot_instance_types = [
     "c7i.xlarge",
@@ -82,7 +82,7 @@ source "amazon-ebs" "build_image_arm64" {
 
   associate_public_ip_address = true
 
-  ssh_interface = "public_ip"
+  ssh_interface = "private_ip"
 
   spot_instance_types = [
     "c7g.xlarge",

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -13,7 +13,7 @@ local "ami_users" {
 packer {
   required_plugins {
     amazon = {
-      version = ">= 1.2.8"
+      version = "= 1.3.1"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -34,7 +34,7 @@ source "amazon-ebs" "build_image" {
 
   associate_public_ip_address = true
 
-  ssh_interface = "private_ip"
+  ssh_interface = "public_ip"
 
   spot_instance_types = [
     "c7i.xlarge",
@@ -82,7 +82,7 @@ source "amazon-ebs" "build_image_arm64" {
 
   associate_public_ip_address = true
 
-  ssh_interface = "private_ip"
+  ssh_interface = "public_ip"
 
   spot_instance_types = [
     "c7g.xlarge",

--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -13,7 +13,7 @@ local "ami_users" {
 packer {
   required_plugins {
     amazon = {
-      version = "= 1.3.1"
+      version = "= 1.8.0"
       source  = "github.com/hashicorp/amazon"
     }
   }


### PR DESCRIPTION
Currently our packer builds for the runner images are failing, the purpose of this PR is to figure out the cause of the issues and fix them.

From what was found during the debug, the following steps fixed the build issue:

- Modified the instance type to an instance with less spot interruption.
- Increasing the timeout duration for ssh into the instance after the reboot.
- Pin the Amazon plugin to 1.8.0, currently it is thought that the issue is caused by the following https://github.com/hashicorp/packer-plugin-amazon/issues/676.
- Skip a test directed towards Azure instances that was failing for us since we run on AWS.

Based on the following test workflow run it can be verified that the fix worked https://github.com/frgrisk/runner-images/actions/runs/27330609191/job/80741874547.